### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mystik20009/77ef9cf5-9484-4403-9acc-cbea7d3f4d01/04f3e225-bf57-4125-abe4-8f24177e5b71/_apis/work/boardbadge/75d83123-3940-4042-81f6-a6b02d16e61a)](https://dev.azure.com/mystik20009/77ef9cf5-9484-4403-9acc-cbea7d3f4d01/_boards/board/t/04f3e225-bf57-4125-abe4-8f24177e5b71/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mystik20009/77ef9cf5-9484-4403-9acc-cbea7d3f4d01/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.